### PR TITLE
ci: allow renovate to use single PR for minor/patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "packageRules": [
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    }
 }


### PR DESCRIPTION
Currently renovate will create a separate PR for each dependency update. For minor and patch versions it is acceptable to group these together and take multiple at once.