### PR TITLE
fix: ignore ebs volumes with no SnapshotId

### DIFF
--- a/ami_deprecation_tool/api.py
+++ b/ami_deprecation_tool/api.py
@@ -142,7 +142,11 @@ def _get_snapshot_ids(image: ImageTypeDef) -> list[str]:
     :return: a list of snapshot ids associated with the given image
     :rtype: list[str]
     """
-    return [device["Ebs"]["SnapshotId"] for device in image["BlockDeviceMappings"] if "Ebs" in device]
+    return [
+        device["Ebs"]["SnapshotId"]
+        for device in image["BlockDeviceMappings"]
+        if "Ebs" in device and "SnapshotId" in device["Ebs"]
+    ]
 
 
 def _concurrent_map_operation(


### PR DESCRIPTION
When finding associated snapshots a SnapshotId was assumed to be present. This is not the case in at least one AMI so an additional check is added.