### PR TITLE
feat: add options to config file to support better filtering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,16 +17,24 @@ Policy Definition
 
 .. code-block:: yaml
 
-  images:
-    some/image/path/image-A-$serial:
-      action: delete
-      keep: 1
-    some/image/path/image-B-$serial:
-      action: deprecate
-      keep: 3
+  ami-deprecation-tool:
+    options:
+      executable_users:
+        - all  # public images only
+      include_deprecated: false
+      include_disabled: false
+    images:
+      some/image/path/image-A-$serial:
+        action: delete
+        keep: 1
+      some/image/path/image-B-$serial:
+        action: deprecate
+        keep: 3
 
 In the above example, ``some/image/path/image-A-$serial`` will find all images across all regions (owned by the current user) matching ``some/image/path/image-A-*`` where serial is replaced with a wildcard. These images will then be sorted by whatever matches in the place of $serial. The policy defined for this image is ``{action: delete, keep 1}`` meaning delete/deregister all except the latest image as defined by the sorted serials.
 
 The second image (``some/image/path/image-A-$serial``) has a policy of ``{action: deprecate, keep 3}``. Rather than deregistering the AMIs, all but the latest three will be scheduled for deprecation 1 minute in the future. These images will not be visible in the browser and will only show in API results if the caller specifies they are searching for deprecated AMIs
 
 **Note: $serial is assumed to be consistently sortable using normal alphanumeric sorting**
+
+`executable_users` is a list of of accounts that can execute the images to be considered. It can include two special values, `self` and `all` where self is strictly private iamges and `all` which is all public AMIs. These values are passed directly to the AWS api and as such any of [their documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_images.html) on the field applies.

--- a/ami_deprecation_tool/cli.py
+++ b/ami_deprecation_tool/cli.py
@@ -44,7 +44,7 @@ def _load_policy(policy_path: str) -> ConfigModel:
     with open(policy_path) as fh:
         config = yaml.safe_load(fh)
     try:
-        return ConfigModel(**config)
+        return ConfigModel(**config["ami-deprecation-tool"])
     except ValidationError as e:
         sys.exit(e.json())
 

--- a/ami_deprecation_tool/configmodels.py
+++ b/ami_deprecation_tool/configmodels.py
@@ -14,9 +14,27 @@ class ConfigPolicyModel(BaseModel):
     keep: int = Field(description="The number of AMIs to exempt from the policy")
 
 
+class ConfigOptionsModel(BaseModel):
+    """
+    Tool configuration model
+    """
+
+    executable_users: list[str] = Field(
+        default=[],
+        description=(
+            "List of accounts with run permissions. Special values 'self' and"
+            " 'all' are permitted. An empty list will allow all"
+            " configurations."
+        ),
+    )
+    include_deprecated: bool = Field(default=False, description=("Include deprecated images in policy application"))
+    include_disabled: bool = Field(default=False, description=("Include disabled images in policy application"))
+
+
 class ConfigModel(BaseModel):
     """
     The base model for configuration
     """
 
+    options: ConfigOptionsModel
     images: dict[str, ConfigPolicyModel]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+# from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from ami_deprecation_tool import configmodels
+
+
+@pytest.mark.parametrize(
+    "config,expected_exec_users,expected_deprecated,expected_disabled",
+    [
+        ({}, [], False, False),
+        ({"include_deprecated": True, "include_disabled": False}, [], True, False),
+        ({"include_deprecated": False, "include_disabled": True}, [], False, True),
+        ({"executable_users": ["all"]}, ["all"], False, False),
+        ({"executable_users": ["123", "456", "789"]}, ["123", "456", "789"], False, False),
+        ({"executable_users": ["self"], "include_deprecated": True, "include_disabled": True}, ["self"], True, True),
+    ],
+)
+def test_config_options(
+    config,
+    expected_exec_users,
+    expected_deprecated,
+    expected_disabled,
+):
+    options = configmodels.ConfigOptionsModel(**config)
+    assert options.executable_users == expected_exec_users
+    assert options.include_disabled == expected_disabled
+    assert options.include_deprecated == expected_deprecated


### PR DESCRIPTION
Previously all images (regardless of public/private/share settings) were considered when applying deprecation policies. While potentially desirable this can lead to potentially unexpected outcomes (e.g. keeping the latest 3 images keeping 3 private images and none being available publicly). This change adds configuration options to expose some filtering options like 'executable_users'.