### PR TITLE
feat: add output for actions taken (or intended)

### DIFF
--- a/ami_deprecation_tool/cli.py
+++ b/ami_deprecation_tool/cli.py
@@ -25,17 +25,21 @@ from .configmodels import ConfigModel
     count=True,
     help="Set log verbosity. The default log level is WARNING. '-v' will set to INFO and '-vv' will set to DEBUG",
 )
+@click.option("-o", "--output-actions", type=str, help="yaml file to write action log to")
 @click.option(
     "--dry-run/--no-dry-run",
     "dry_run",
     default=True,
     help="Prevent deprecation, only log intended actions (default=True)",
 )
-def deprecate(policy_path, log_level, dry_run):
+def deprecate(policy_path, log_level, output_actions, dry_run):
     _setup_logging(log_level)
     config = _load_policy(policy_path)
     try:
-        api.deprecate(config, dry_run)
+        actions = api.deprecate(config, dry_run)
+        if output_actions:
+            with open(output_actions, "w") as fh:
+                yaml.dump(actions, fh)
     except ClientError as e:
         sys.exit(e)
 


### PR DESCRIPTION
Actions are logged, but parsing a large log file to determine what was done can be difficult. This change adds an output option to record what action was taken on as part of a given rule.

Example output showing showing a "delete all but 1" policy where 3 images would be deleted, 1 is kept, and 1 is skipped for not being present in all regions:

```yaml
my-cool-image-*: !!python/object:ami_deprecation_tool.api.Actions
  images: !!python/object:ami_deprecation_tool.api.ActionImages
    delete:
    - my-cool-image-1
    - my-cool-image-2
    - my-cool-image-3
    deprecate: []
    keep:
    - my-cool-image-4
    skip:
    - my-cool-image-5
  policy:
    action: delete
    keep: 1
```