### PR TITLE
Fix datetime issue in Python 3.10

### DIFF
--- a/ami_deprecation_tool/api.py
+++ b/ami_deprecation_tool/api.py
@@ -107,7 +107,7 @@ def _image_is_expired(images: list[RegionImageContainer], policy: ConfigPolicyMo
     """
 
     # check if the image is has existed longer than keep_days days
-    cutoff = dt.datetime.now() - dt.timedelta(days=policy.keep_days)
+    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=policy.keep_days)
 
     return images[0].creation_date < cutoff
 
@@ -266,7 +266,7 @@ def _deprecate_image(image_name: str, clients: dict[str, EC2Client], image: Regi
         client.enable_image_deprecation,
         {
             "ImageId": image.image_id,
-            "DeprecateAt": str(dt.datetime.now() + dt.timedelta(minutes=1)),
+            "DeprecateAt": str(dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=1)),
             "DryRun": dry_run,
         },
     )

--- a/ami_deprecation_tool/api.py
+++ b/ami_deprecation_tool/api.py
@@ -80,7 +80,7 @@ def deprecate(config: ConfigModel, dry_run: bool) -> dict[str, Actions]:
                     RegionImageContainer(
                         region,
                         image["ImageId"],
-                        dt.datetime.fromisoformat(str(image["CreationDate"])),
+                        dt.datetime.fromisoformat(str(image["CreationDate"]).replace("Z", "+00:00")),
                         _get_snapshot_ids(image),
                     )
                 )
@@ -193,7 +193,9 @@ def _get_images(client: EC2Client, name: str, options: ConfigOptionsModel) -> li
         deprecation_time = image.get("DeprecationTime", "")
         if not deprecation_time:
             return False
-        if dt.datetime.fromisoformat(deprecation_time.rstrip("Z")) > dt.datetime.now():
+        if dt.datetime.fromisoformat(deprecation_time.rstrip("Z")).replace(tzinfo=dt.timezone.utc) > dt.datetime.now(
+            dt.timezone.utc
+        ):
             return False
         return True
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from ami_deprecation_tool import api, configmodels
 
-ONE_MONTH_AGO = datetime.now() - timedelta(days=30)
-SIX_MONTHS_AGO = datetime.now() - timedelta(days=180)
+ONE_MONTH_AGO = datetime.now(timezone.utc) - timedelta(days=30)
+SIX_MONTHS_AGO = datetime.now(timezone.utc) - timedelta(days=180)
 
 
 def mk_image(image_id, name, date):
@@ -94,7 +94,7 @@ def test_get_images_options(mock_boto, options_dict):
     mock_client = mock_boto.client.return_value
     options = configmodels.ConfigOptionsModel(**options_dict)
     image_name = "image-name"
-    future_deprecation_time = (datetime.now() + timedelta(minutes=5)).isoformat()
+    future_deprecation_time = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
 
     mock_images = {
         "Images": [


### PR DESCRIPTION
Core22 (Python 3.10) `fromisoformat` does not support the "Z" string. Stripped "Z" for compatible parsing and matched the timezone format with AWS for correct comparison.